### PR TITLE
[codex] Update Fall 2026 course website

### DIFF
--- a/assets/css/style_s2025.css
+++ b/assets/css/style_s2025.css
@@ -426,6 +426,29 @@ h1, h2, h3, h4, h5, h6 {
   visibility: hidden;
 }
 
+.nav-menu li.apply-btn a {
+  color: #fff;
+  background: #A31F34;
+  padding: 7px 22px;
+  border-radius: 50px;
+  border: 2px solid #A31F34;
+  transition: all ease-in-out 0.3s;
+  font-weight: 500;
+  margin-left: 8px;
+  margin-top: 2px;
+  line-height: 1;
+  font-size: 13px;
+}
+
+.nav-menu li.apply-btn a:hover {
+  background: none;
+  color: #A31F34;
+}
+
+.nav-menu li.apply-btn:hover a:before, .nav-menu li.apply-btn.menu-active a:before {
+  visibility: hidden;
+}
+
 .nav-menu ul {
   margin: 4px 0 0 0;
   padding: 10px;
@@ -673,8 +696,43 @@ body.mobile-nav-active #mobile-nav-toggle {
 }
 
 @media (max-width: 500px) {
+  html,
+  body {
+    overflow-x: hidden;
+  }
   #intro {
     height: 90vh;
+    width: 100vw;
+  }
+  #intro .intro-container {
+    width: 100vw;
+    max-width: 100vw;
+    right: auto;
+  }
+  #intro h1 {
+    font-size: 28px;
+    line-height: 1.2;
+  }
+  #intro h2 {
+    font-size: 24px;
+    line-height: 1.25;
+  }
+  #intro h3 {
+    font-size: 22px;
+    line-height: 1.25;
+  }
+  #sub-heading {
+    font-size: 17px!important;
+    line-height: 1.35;
+  }
+  #intro h1,
+  #intro h2,
+  #intro h3,
+  #intro p,
+  #sub-heading {
+    max-width: calc(100vw - 30px);
+    white-space: normal;
+    overflow-wrap: break-word;
   }
   #about h2 {
     text-align: center;
@@ -1798,6 +1856,242 @@ Secondary Speakers Section
   animation-delay: 0.8s;
   border: 2px solid #A31F34;
   background-color:rgb(255, 196, 196);
+}
+
+.studio-light-section {
+  background-color: #f4f7ff;
+  padding: 60px 10% 40px;
+}
+
+.studio-dark-section {
+  background-color: rgb(143, 33, 51);
+  padding: 60px 10% 40px;
+}
+
+.studio-grid {
+  display: grid;
+  gap: 22px;
+  margin-bottom: 24px;
+}
+
+.studio-grid.two-col {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.studio-panel,
+.studio-panel-dark {
+  border-radius: 8px;
+  padding: 22px;
+  min-height: 100%;
+}
+
+.studio-panel {
+  background: #fff;
+  border: 1px solid #e1e6f4;
+  color: #191919;
+}
+
+.studio-panel-dark {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  color: #fff;
+}
+
+.studio-panel h3,
+.studio-panel-dark h3 {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin-bottom: 14px;
+}
+
+.studio-panel h3 {
+  color: #191919;
+}
+
+.studio-panel-dark h3 {
+  color: #fff;
+}
+
+.studio-panel p,
+.studio-panel-dark p {
+  margin-bottom: 0;
+  line-height: 1.55;
+}
+
+.studio-panel ul,
+.studio-panel-dark ul {
+  padding-left: 20px;
+  margin-bottom: 0;
+}
+
+.studio-panel p + ul,
+.studio-panel-dark p + ul {
+  margin-top: 14px;
+}
+
+.studio-panel li,
+.studio-panel-dark li {
+  margin-bottom: 8px;
+  font-size: 0.98rem;
+  line-height: 1.5;
+}
+
+.studio-panel li {
+  color: #191919;
+}
+
+.studio-panel-dark li {
+  color: #fff;
+}
+
+.studio-kicker {
+  color: #fff;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  max-width: 920px;
+  margin: 0 auto 28px;
+  text-align: center;
+}
+
+.studio-copy-dark {
+  color: #191919;
+  font-size: 1rem;
+  line-height: 1.65;
+  max-width: 960px;
+  margin: 0 auto 28px;
+  text-align: center;
+}
+
+.studio-note,
+.studio-note-dark {
+  border-radius: 8px;
+  padding: 18px 22px;
+  font-size: 1rem;
+  line-height: 1.55;
+}
+
+.studio-note {
+  background: #fff4d8;
+  border: 1px solid #f0cf78;
+  color: #191919;
+}
+
+.studio-note-dark {
+  background: rgba(255, 244, 216, 0.14);
+  border: 1px solid rgba(255, 244, 216, 0.45);
+  color: #fff;
+}
+
+#coordination.studio-overview {
+  padding-bottom: 48px;
+}
+
+#coordination.studio-overview .section-header-inv {
+  margin-bottom: 34px;
+}
+
+#coordination.studio-overview .studio-kicker {
+  font-size: 1rem;
+  line-height: 1.55;
+  max-width: 980px;
+  margin-bottom: 24px;
+}
+
+#coordination.studio-overview .studio-grid {
+  gap: 18px;
+  margin-bottom: 18px;
+}
+
+#coordination.studio-overview .studio-panel-dark {
+  padding: 20px 22px;
+}
+
+#coordination.studio-overview .studio-panel-dark h3 {
+  font-size: 1.05rem;
+  line-height: 1.3;
+  margin-bottom: 10px;
+}
+
+#coordination.studio-overview .studio-panel-dark p,
+#coordination.studio-overview .studio-panel-dark li {
+  font-size: 0.94rem;
+  line-height: 1.48;
+}
+
+#coordination.studio-overview .studio-panel-dark li {
+  margin-bottom: 7px;
+}
+
+#coordination.studio-overview .studio-panel-dark ul {
+  padding-left: 18px;
+}
+
+#coordination.studio-overview .studio-note-dark {
+  font-size: 0.94rem;
+  line-height: 1.48;
+  padding: 16px 18px;
+}
+
+#coordination.studio-course-outline .studio-kicker {
+  font-size: 1rem;
+  line-height: 1.55;
+  max-width: 960px;
+  margin-bottom: 24px;
+}
+
+#coordination.studio-course-outline .studio-panel-dark h3 {
+  font-size: 1.05rem;
+  line-height: 1.3;
+  margin-bottom: 10px;
+}
+
+#coordination.studio-course-outline .studio-panel-dark li {
+  font-size: 0.94rem;
+  line-height: 1.48;
+  margin-bottom: 7px;
+}
+
+.studio-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  color: #191919;
+  border: 1px solid #e1e6f4;
+}
+
+.studio-table th,
+.studio-table td {
+  padding: 14px 16px;
+  border: 1px solid #e1e6f4;
+  vertical-align: top;
+  line-height: 1.5;
+}
+
+.studio-table th {
+  background: #A31F34;
+  color: #fff;
+  font-weight: 700;
+}
+
+.studio-table td:first-child {
+  width: 120px;
+  font-weight: 700;
+}
+
+@media (max-width: 768px) {
+  .studio-light-section,
+  .studio-dark-section {
+    padding: 50px 7% 30px;
+  }
+
+  .studio-grid.two-col {
+    grid-template-columns: 1fr;
+  }
+
+  .studio-table th,
+  .studio-table td {
+    padding: 12px;
+  }
 }
 
 /*--------------------------------------------------------------

--- a/fall26-v0.html
+++ b/fall26-v0.html
@@ -6,7 +6,8 @@
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
   <title>AI Studio | Fall 2026</title>
-    <meta content="MIT, AI Studio, Fall 2026, MAS.665, AI agents, agentic web" name="keywords">
+    <meta content="Fall 2026 AI Studio @ MIT" name="descriptison">
+    <meta content="MIT, AI Studio, Fall 2026, MAS.665" name="keywords">
 
     <!-- Favicons -->
     <link rel="icon" type="image/png" sizes="96x96" href="assets/img/ai-studio-logo-96.png">
@@ -14,7 +15,7 @@
 
     <meta name="title" content="AI Studio Fall 2026 @ MIT">
     <meta name="description"
-      content="AI Studio Fall 2026 @ MIT: a hands-on course where students build infrastructure and products for AI agents and the emerging agentic web.">
+      content="AI Studio Fall 2026 @ MIT">
     <meta property="og:image" content="assets/img/ai-studio-logo-180.png">
 
     <!-- Google Fonts -->
@@ -84,13 +85,9 @@
           <li><a href="#">Fall 2026</a>
             <ul>
               <li><a href="#overview">Overview</a></li>
-              <li><a href="#admissions">Admissions</a></li>
-              <li><a href="#projects">Projects</a></li>
-              <li hidden><a href="#grading">Grading</a></li>
               <li><a href="#speakers">Instructors</a></li>
               <li><a href="#background">Background</a></li>
               <li><a href="#course">Course Outline</a></li>
-              <li><a href="#faq">FAQ</a></li>
             </ul>
           </li>
           <li><a href="#">Past Semesters</a>
@@ -103,7 +100,7 @@
               <li><a href="fall23.html">Fall 2023</a></li>
             </ul>
           </li>
-          <li class="apply-btn"><a href="https://forms.gle/qD21EGUYxMnqYsN39">Apply Now</a></li>
+          <li class="apply-btn"><a href="#overview">Apply Now</a></li>
         </ul>
       </nav><!-- #nav-menu-container -->
     </div>
@@ -125,7 +122,7 @@
 
 
       <h1 class="mb-2 pb-0"><span style="color: #A31F34">AI Studio Course</span></h1>
-      <h2 class="mb-2 pb-0"><span style="color: #A31F34">Infrastructure and Products for AI Agents</span></h2>
+      <h2 class="mb-2 pb-0"><span style="color: #A31F34">AI Agents and Agentic Web</span></h2>
       <h3 class="mb-2 pb-0"><span style="color: #A31F34; font-weight: bold">MAS.665</span></h3>
       <p id="sub-heading" class="mb-4 pb-0">MAS.664 / MAS.665 / EC.731 / IDS.865</p>
       <p class="mb-0 pb-0">(prev: Foundations of AI Ventures, AI Venture Studio, AI for Impact)</p>
@@ -152,223 +149,62 @@
 
 
   <main id="main">
-    <section id="coordination" class="section-with-bg studio-overview">
+    <section id="coordination" class="section-with-bg">
       <div class="container" id="overview">
         <div class="section-header-inv">
           <h2 style="font-size:xx-large">Overview</h2>
         </div>
-        <div data-aos-delay="700">
+        <div class="justify-content-center" data-aos-delay="700">
 
-        <p class="studio-kicker">
-          Build the infrastructure and products that make the agentic web possible, including APIs, tools, services, shared standards, environments, and trust systems that AI agents can find, use, combine, and rely on.
+        <p style="color: white">
+
+          <b>Build the agentic future</b>
+          <br>
+            This MIT course teaches students to build autonomous AI agents that plan, coordinate, and execute complex workflows across distributed web systems. Students learn agent architectures, inter-agent protocols, web automation frameworks, and methods for decentralized coordination, while mastering AI-native coding and multimodal integration.
+            <br><br>
+            Through hands-on projects, students build sophisticated agentic applications: from automated workflow orchestration to intelligent web scraping and dynamic API coordination. The course combines solid technical foundations with innovative product development opportunities in this emerging infrastructure layer. Students learn to design AI agents with global impact, validate ideas through AI-assisted research and interviews, and move working prototypes toward market-ready solutions.
+            <br><br>
+            The course features insights from distributed AI researchers, web platform architects, and technical founders. It culminates with a technical demo day showcasing next-generation agentic web systems.
+          <br><br>
+
+          <b>Course pillars</b>
+          <br/>
+          1. Innovation (20%): Cultivating a deep understanding of where AI is going to be in 2-3 years or more. Multimodal reasoning, autonomous workflows, personalized agents, robotics, and more.
+          <br>
+          2. Human Centered design and Final Project (30%): Learn how to design innovative AI products that can make a truly global impact, validate ideas with AI-powered outreach and interviews, for compelling market-ready solutions.
+          <br>
+          3. Technical Building (50%): We will teach you about hands-on creation of agentic systems, LLM-based tools, and automated pipelines using the latest AI stacks and frameworks.
+          <br>
+
+
+        <br>
+        <b>Follow these steps to register for the course:</b>
+        </p>
+        <ul style="font-size:0.85rem; margin-top: -1.5rem;">
+          <li>Step 0: <a href="https://forms.gle/qD21EGUYxMnqYsN39" style="color:yellow;">Fill out the Fall 2026 questionnaire</a>.</li>
+          <li>Step 1: Course registration logistics for MIT and Harvard students are <em>TBA</em>.</li>
+          <li>Step 2: Recommended prep work + mini build sprint is <em>TBA</em> (expect short AI tooling primers).</li>
+          <li>Step 3: Application review dates are <em>TBA</em>. We will notify both accepted and rejected students by email. Submitting required forms does not guarantee acceptance due to limited space and high interest in the class.</li>
+          <li>Step 4: Late application and reconsideration process is <em>TBA</em>.</li>
+        </ul>
+
+        <p style="color: white">
+          Pre-Course Info Session &amp; Social: <em>TBA</em>
         </p>
 
-        <div class="studio-grid two-col dark">
-          <div class="studio-panel-dark">
-            <h3>Build Infrastructure and Products for AI Agents</h3>
-            <p>
-              In this course, you will design software that AI agents can use directly to complete tasks and interact with other systems. Together, these connected agents, tools, and services form the agentic web.
-            </p>
-            <ul>
-              <li>Create APIs, tools, and services that agents can discover and use.</li>
-              <li>Build essential capabilities such as identity, memory, permissions, payments, monitoring, testing, and security.</li>
-              <li>Test whether agents can understand your system, use it correctly, and combine it with other tools.</li>
-            </ul>
-          </div>
+        <center>
+          <p style="color: white"><b>
+          Class Schedule: Thursdays, 10 AM-12 PM, Room E14-633, MIT Media Lab (starting Sep 3 or Sep 10).
+          </b></p>
+          <p style="color: white; margin-bottom:0;">Final start date and calendar links will be posted once finalized.</p>
 
-          <div class="studio-panel-dark">
-            <h3>Course Pillars</h3>
-            <ul>
-              <li><strong>Innovation (20%):</strong> explore how AI may change over the next 2&ndash;3 years, including autonomous workflows, shared standards for the agentic web, multimodal reasoning, robotics, and services used by agents.</li>
-              <li><strong>Agent Infrastructure and Products (30%):</strong> design useful infrastructure, services, and products for AI agents and the agentic web.</li>
-              <li><strong>Technical Building (50%):</strong> use current AI tools and frameworks to build working agent systems, LLM-powered tools, APIs, and automated workflows.</li>
-            </ul>
-          </div>
-        </div>
-
-        <div class="studio-grid two-col dark">
-          <div class="studio-panel-dark">
-            <h3>Course Format</h3>
-            <ul>
-              <li>Weekly class meetings on Thursdays, 10:00 AM&ndash;12:00 PM, with lectures, discussion, and applied examples.</li>
-              <li>Regular assignments and quizzes on agent tools, APIs, testing, and deployment.</li>
-              <li>Hands-on project work in small teams of 1&ndash;3 students throughout the semester, with workshops when scheduled.</li>
-              <li>A team final project with checkpoints, mentor feedback, and a Demo Day in December 2026.</li>
-            </ul>
-          </div>
-
-          <div class="studio-panel-dark">
-            <h3>What You Will Deliver</h3>
-            <ul>
-              <li>A working product, service, shared standard, or infrastructure component that contributes to the agentic web.</li>
-              <li>A clear way for agents to interact with it, such as an API, tool interface, or environment where the agent runs.</li>
-              <li>Documentation showing how an agent uses it, plus evidence that it works in realistic scenarios.</li>
-              <li>The semester ends with a concise final presentation and live technical demo.</li>
-            </ul>
-          </div>
-        </div>
+          <br><br>
+        </center>
 
         </div>
       </div>
     </section>
 
-    <section id="admissions" class="studio-light-section">
-      <div class="container">
-        <div class="section-header">
-          <h2 style="color: #191919; font-size:xx-large">Admissions and Logistics</h2>
-        </div>
-
-        <div class="studio-grid two-col">
-          <div class="studio-panel">
-            <h3>Application Waves</h3>
-            <ul>
-              <li><strong>First wave:</strong> apply by August 1, 2026.</li>
-              <li><strong>Second wave:</strong> apply by August 15, 2026.</li>
-              <li><strong>Final wave:</strong> apply by September 1, 2026.</li>
-              <li><strong>Late applications:</strong> a few seats may be available after September 1, but admission is not guaranteed.</li>
-            </ul>
-          </div>
-
-          <div class="studio-panel">
-            <h3>How Applications Are Reviewed</h3>
-            <ul>
-              <li>We look for readiness to build, relevant experience, clear interest in the course, and the ability to contribute to a project team.</li>
-              <li>Strong early applicants may receive a decision before the semester starts. Other applicants may be placed on a waitlist until course capacity is confirmed.</li>
-              <li>The course is selective, so completing every required step does not guarantee admission.</li>
-              <li>MIT registration or Canvas access does not replace the course application; students who already have Canvas access should follow the Getting Started announcement and complete the same application steps.</li>
-            </ul>
-          </div>
-        </div>
-
-        <div class="studio-grid two-col">
-          <div class="studio-panel">
-            <h3>Required Application Materials</h3>
-            <ul>
-              <li>Complete the <a href="https://forms.gle/qD21EGUYxMnqYsN39">Fall 2026 questionnaire</a>.</li>
-              <li>Submit the required short mini-project on AI agents. Details will be announced in mid-July 2026, and the project will be reviewed as part of your application.</li>
-              <li>Complete any additional registration forms required by MIT or Harvard.</li>
-            </ul>
-          </div>
-
-          <div class="studio-panel">
-            <h3>How to Contact the Course Team</h3>
-            <ul>
-              <li>Once admitted, use Canvas for assignments, deadlines, project questions, logistics, and other general questions.</li>
-              <li>Use email only for private matters that include sensitive personal information. When asking for help by email, include your full name, school, team (if applicable), and the specific question or action you need.</li>
-              <li>Use the same full name and email address throughout your application, Canvas profile, course communications, and project work so we can identify you easily.</li>
-            </ul>
-          </div>
-        </div>
-
-        <div class="studio-note">
-          The course may use an AI agent to answer common logistics questions, route support requests, and help students find Canvas materials. Course staff remain the escalation path for admissions, grading, and policy decisions.
-        </div>
-      </div>
-    </section>
-
-    <section id="projects" class="studio-dark-section">
-      <div class="container">
-        <div class="section-header-inv">
-          <h2 style="font-size:xx-large">Projects and Demo Day</h2>
-        </div>
-
-        <p class="studio-kicker">
-          Fall 2026 projects will contribute to the emerging agentic web: software that AI agents can use to complete tasks and interact with other agents and services.
-        </p>
-
-        <div class="studio-grid two-col dark">
-          <div class="studio-panel-dark">
-            <h3>Project Scope</h3>
-            <ul>
-              <li>Examples include an agent-ready product, an API-based service, an infrastructure component, an environment for agents, or a security and reliability tool, among other possibilities.</li>
-              <li>Your project should solve a clear problem and explain exactly what an AI agent can do with it.</li>
-              <li>Design your system for the agentic web so it can work with other agents, services, and infrastructure.</li>
-              <li>Example areas include identity, reputation, permissions, payments, memory, monitoring, evaluation, adversarial testing, service marketplaces, and workflow automation.</li>
-            </ul>
-          </div>
-
-          <div class="studio-panel-dark">
-            <h3>Demo Day Requirements</h3>
-            <ul>
-              <li>Demo Day is planned for December 2026; the exact date will be announced later.</li>
-              <li>Two weeks before Demo Day, each team must submit its final title, team list, project URL, presentation deck, and any table or booth needs.</li>
-              <li>After that deadline, teams may not change projects, swap demos, or request major logistics changes.</li>
-              <li>Each project will have 2&ndash;3 minutes for its live demo.</li>
-              <li>Missing the submission deadline or the presentation may reduce or eliminate the project and Demo Day portion of the grade.</li>
-            </ul>
-          </div>
-        </div>
-
-        <div class="studio-grid two-col dark">
-          <div class="studio-panel-dark">
-            <h3>Mentor Feedback</h3>
-            <ul>
-              <li>Each team is expected to work with at least one mentor.</li>
-              <li>Teams should plan for three mentor meetings during the semester.</li>
-              <li>Mentors will be matched to a small number of projects so feedback can be specific.</li>
-              <li>Teams should come to mentor sessions with specific technical questions, a working artifact, and clear next steps.</li>
-            </ul>
-          </div>
-
-          <div class="studio-panel-dark">
-            <h3>Technical Support</h3>
-            <ul>
-              <li>Technical workshops and support sessions will be offered during the semester.</li>
-              <li>Topics and timing may be announced in advance throughout the semester.</li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section id="grading" class="studio-light-section" hidden>
-      <div class="container">
-        <div class="section-header">
-          <h2 style="color: #191919; font-size:xx-large">Grading</h2>
-        </div>
-
-        <p class="studio-copy-dark">
-          Grades are based on three areas: Innovation (20%), Agent Infrastructure and Products (30%), and Technical Building (50%). Attendance, quizzes, peer feedback, work with mentors, and preparation for Demo Day contribute to those areas.
-        </p>
-
-        <div class="table-responsive">
-          <table class="studio-table">
-            <thead>
-              <tr>
-                <th>Grade</th>
-                <th>What it means</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>A+</td>
-                <td>An exceptional technical project with original insight, strong evidence that agents can use it reliably, a polished demo completed before the submission deadline, clear documentation, helpful peer feedback, and three productive mentor meetings.</td>
-              </tr>
-              <tr>
-                <td>A</td>
-                <td>All required work completed on time, a strong working prototype or infrastructure component, a clearly documented interface for agents, solid technical execution, active participation, and an on-time Demo Day presentation.</td>
-              </tr>
-              <tr>
-                <td>A-</td>
-                <td>Complete and serious work with minor gaps in technical depth, testing, polish, documentation, or consistency. The demo works, but the project is less reliable or ambitious than A-level work.</td>
-              </tr>
-              <tr>
-                <td>B+ / B</td>
-                <td>Substantial participation and a partially working project, but one major area needs improvement: a missed milestone, limited technical implementation or testing, weak collaboration, or an incomplete final demo.</td>
-              </tr>
-              <tr>
-                <td>B- / C</td>
-                <td>Inconsistent participation, late or missing assignments, limited project progress, poor communication, or a demo that does not show a working system.</td>
-              </tr>
-              <tr>
-                <td>No credit / Fail</td>
-                <td>Required work or presentations are missing, academic integrity rules are violated, or the student repeatedly does not respond to course requirements and staff.</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </section>
 
     <div id="vaccines-for-all">
       <!-- ======= agenda Section =======  -->
@@ -480,8 +316,8 @@
           <div class="section-header">
             <h2 style="color: #191919">Mentors and Guest Speakers</h2>
           </div>
-          <p style="color: #191919; text-align: center; font-size: 1.1rem; max-width: 900px; margin: 0 auto 30px;">
-            Fall 2026 mentors and speakers will be announced throughout the semester. We are inviting technical founders, engineers, researchers, and investors who can give practical feedback on system design, product strategy, deployment, reliability, and bringing a product to market.
+          <p style="color: #191919; text-align: center; font-size: 1.1rem;">
+            To be announced
           </p>
 
         </div>
@@ -491,18 +327,19 @@
 
 
 
-    <section class="studio-light-section">
+    <section id="coordination" style="background-color: #f4f7ff;">
       <div class="container" id="background">
         <div class="section-header">
           <h2 style="color: #191919; font-size:xx-large">Background</h2>
         </div>
 
-        <div data-aos-delay="700">
+        <div class= data-aos-delay="700">
           <p style="color: #191919">
-            The course evolved from Sandy Pentland's Development Ventures and has a long track record of helping students turn class projects into working products and ventures.
-          </p>
-
-          <p style="color: #191919; margin-bottom: 12px;">Previous offerings:</p>
+          Almost 25% of students from this course transform their projects into innovative products. The program, which evolved from Sandy Pentland's "Development Ventures," has established a strong track record of launching successful student projects through its Demo Day showcase.
+          <br>
+          <br>
+          Our previous class links can be found here:
+          <br>
           <ul style="font-size:0.85rem; padding-right: 8rem;">
             <li><a href="https://aiforimpact.github.io/spring26.html">Spring'26: AI Studio</a></li>
             <li><a href="https://aiforimpact.github.io/fall25.html">Fall'25: AI Studio</a></li>
@@ -518,71 +355,123 @@
             <li><a href="https://web.archive.org/web/https://stellar.mit.edu/S/course/MAS/fa20/MAS.665/">Fall'20: Global Ventures ~ Data and AI for Resilience after COVID19</a></li>
             <li><a href="https://web.archive.org/web/https://stellar.mit.edu/S/course/MAS/sp20/MAS.664/">Spring'20: AI for Impact ~ Towards Solving Societal-Scale Problems via Media Ventures</a></li>
           </ul>
+          </p>
+
+          <p style="color: #191919">
+          All other previous AI for Impact/Global Ventures class links can be found here:
+
+          <br>
+
+          <ul style="font-size:0.85rem; padding-right: 8rem;">
+            <li><a href="https://web.archive.org/web/https://stellar.mit.edu/courseguide/course/MAS/sp22/MAS.664/index.html">Fall Term</a></li>
+            <li><a href="https://web.archive.org/web/https://stellar.mit.edu/courseguide/course/MAS/fa21/MAS.665/index.html">Spring Term</a></li>
+          </ul>
+          </p>
+
+          <!-- A recent MIT News article talked about the history of our course "AI for Impact" (MAS.664) and its evolution over time. The entrepreneurship-focused class has a history of about a quarter of students continuing on to start real ventures. The course started by Sandy Pentland, earlier called Development Ventures was focused on leveraging entrepreneurship to drive societal scale impact. The highly anticipated Demo Day showcase has also been reported on. -->
+          <!-- Almost 25% of course's students launch startups from their projects. The course has a history of innovation, and a long history of innovation as outlined in these news articles.  -->
+          <!-- Almost 25% of students from this course transform their projects into startups. The program, which evolved from Sandy Pentland's "Development Ventures," has established a strong track record of launching successful student ventures through its Demo Day showcase. -->
+          <!-- <br>
+          <br>
+
+          <ul style="font-size:0.85rem; padding-right: 8rem;">
+              <li><a href="https://www.media.mit.edu/posts/ai-and-web3-for-impact-venture-studio-demo-day-2023/">Recent Demo Day Report</a></li>
+              <li><a href="https://news.mit.edu/2021/ai-impact-lives-its-name-0816">MIT News: "AI for Impact" lives up to its name</a></li>
+          </ul> -->
+          <br>
+          <br>
+
+
+          </p>
         </div>
       </div>
     </section>
 
-    <section id="coordination" class="section-with-bg studio-course-outline">
+    <section id="coordination" class="section-with-bg">
       <div class="container" id="course">
         <div class="section-header-inv">
           <h2 style="font-size:xx-large">Course Outline</h2>
         </div>
 
-        <p class="studio-kicker">
-          The detailed weekly calendar is TBA and will be posted once the semester calendar is finalized.
+        <p style="color:white; font-size: 1rem; text-align:center;">
+          Updated Fall 2026 calendar and weekly outline are TBA; expect a similar studio cadence with refreshed themes.
         </p>
 
-        <div class="studio-grid two-col dark">
-          <div class="studio-panel-dark">
-            <h3>Key Dates</h3>
-            <ul>
-              <li><strong>Weekly class:</strong> Thursdays, 10:00 AM&ndash;12:00 PM, in E14-633 at the MIT Media Lab.</li>
-              <li><strong>First class:</strong> September 3 or September 10, 2026; the final date will be announced soon.</li>
-              <li><strong>Final demo materials due:</strong> two weeks before Demo Day.</li>
-              <li><strong>Final presentations and Demo Day:</strong> December 2026.</li>
-            </ul>
-          </div>
+        <br>
 
-          <div class="studio-panel-dark">
-            <h3>Calendar Notes</h3>
-            <ul>
-              <li>The full weekly schedule will be linked here when it is ready.</li>
-              <li>Assignment deadlines and project milestones will be published on Canvas.</li>
-              <li>Workshop, mentor, and guest speaker dates will be announced later.</li>
-              <li>The course may count toward the Entrepreneurship and Innovation Minor. Contact <a href="mailto:eiminor_admin@mit.edu" style="color:yellow;">eiminor_admin@mit.edu</a> to confirm eligibility and requirements.</li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </section>
+        <div class="justify-content-left" data-aos-delay="700">
+          <p style="color: white; font-size:large; margin-bottom: 10px;"><u>Class Goals</u>:</p>
+          <ul style="font-size:0.85rem">
+              <li>Guide students to identify, evaluate, and build high-impact projects with AI. Focus on deep technology applications that are best suited to students with top engineering and design skills at MIT.</li>
+              <li>Advance "Big Ideas" into MVP-seed-stage for commercial consideration.</li>
+              <li>Teach the technical fundamentals of the modern AI stack (rapid prototyping, deployment, and model management). </li>
+              <li>Discuss practical trade-offs in AI product development (model accuracy, efficiency, and latency). </li>
 
 
-    <section id="faq" class="studio-light-section">
-      <div class="container">
-        <div class="section-header">
-          <h2 style="color: #191919; font-size:xx-large">FAQ</h2>
-        </div>
+          </ul>
 
-        <div class="studio-grid two-col">
-          <div class="studio-panel">
-            <h3>Can non-technical students take the course?</h3>
-            <p>Yes. You do not need to be an expert programmer, but you must be ready to contribute to a working technical project. All team members are expected to build with coding agents. Strong teams combine product, design, research, and engineering skills.</p>
-          </div>
 
-          <div class="studio-panel">
-            <h3>What is the Agentic Web?</h3>
-            <p>The Agentic Web is an ecosystem of connected AI agents, tools, services, and shared standards. Agents can discover services, exchange information, and combine tools to complete tasks across different systems.</p>
-          </div>
+          <p style="color: white; font-size:large; margin-bottom: 10px;"><u>Timeline</u>:</p>
+          <ul style="font-size:0.85rem">
+            <li>Meet and greet + team formation mixer: <em>TBA</em></li>
+            <li>First day of class: <em>Thu, Sep 3 or Thu, Sep 10, 2026</em></li>
+            <li>Final class presentations / Demo Day: <em>December 2026</em></li>
+          </ul>
 
-          <div class="studio-panel">
-            <h3>Is collaboration allowed?</h3>
-            <p>Yes. Peer groups and mentor feedback are part of the course. Students should help each other learn while submitting their own work and documenting team contributions clearly.</p>
-          </div>
 
-          <div class="studio-panel">
-            <h3>Who should mentor?</h3>
-            <p>We welcome technical founders, engineers, researchers, and industry partners who can help students build and evaluate real AI agent systems. Interested mentors should contact the course team.</p>
-          </div>
+          <p style="color: white; font-size:large; margin-bottom: 10px;"><u>Class Structure</u>:</p>
+          <ul style="font-size:0.85rem">
+            <li>Studio format, with team projects with 2-3 students per team</li>
+            <li>Guest speakers share leading-edge thinking</li>
+            <li>NB: You can use this course for Entrepreneurship Minor credits. Contact <a href="mailto:eiminor_admin@mit.edu" style="color:yellow;">eiminor_admin@mit.edu</a> for the application form and meet E&I minor advisor, Reza Rahaman (rezar@mit.edu) for sign off.</li>
+            <li>Minimum Viable Product (MVP) by the end of the term</li>
+            <li>Demo Day</li>
+          </ul>
+
+
+          <p style="color: white; font-size:large; margin-bottom: 10px;"><u>Support for Students</u>:</p>
+
+          <ul style="font-size:0.85rem">
+              <li>Weekly class mentor meetings and guest lecture blocks (exact timing TBA)</li>
+              <li>Class visits to local start-ups and technology companies</li>
+              <li>Data and AI scientists from startups for experience</li>
+              <li>Sessions with startup coaches</li>
+          </ul>
+
+          <br/>
+          <br />
+          <!-- <p style="color: white; font-size:x-large; margin-bottom: 10px;"><u>Funding</u>:</p>
+          <ul style="font-size:0.85rem">
+              <li>Teams will receive milestone-based seed funds</li>
+          </ul> -->
+
+
+          <!-- <p style="color: white; font-size:x-large"><u>Course Support</u>:</p>
+          <div class="row justify-content-left speaker-row" style="margin: auto;">
+            <div class="col-lg-3 col-md-6 col-sm-6" style="width: 85%; padding: 1em;">
+              <a href="https://nikhilbehari.github.io" target="_blank">
+                <div class="speaker">
+                  <img src="assets/img/speakers/Nikhil_Behari.png" alt="Nikhil Behari" style="width: 100%; height: 100%; object-fit: cover; aspect-ratio: 1 / 1;">
+                  <div class="details" style="text-align: center; color: white; margin-top: 0.5em;">
+                    <h4 style="color: white; margin-bottom: 0.2em;">Nikhil Behari</h3>
+                    <p style="color: white; margin: 0;">Graduate Student, MIT Media Lab</p>
+                  </div>
+                </div>
+              </a>
+            </div> -->
+
+          <!--
+          <p style="color: white; font-size:x-large"><u>Expected Short and Long Term Outcomes</u>:</p>
+          <ul style="font-size:0.85rem; padding-right:5rem;">
+              <li>Student teams develop MVP and project "pitch" for final review</li>
+              <li>Student teams can submit projects for consideration in venture incubator/accelerators, 100K, Deshpande Grants etc.</li>
+              <li>Projects can be considered for funding by the MIT Engine, E14 Fund, and other investment funds</li>
+              <li>Visualize Venture Studio creates an annual event to invite key stakeholders including the general innovation community to showcase big project ideas</li>
+              <li>Visualize Venture Studio creates a funded consortium (GIFTS) with on-going course sponsorship from a diverse group of financial institutions (e.g., Venture capital firms of all stages, Investment Banks, LPs, family offices, and HNW individuals), corporates, and NGOs. No branding is allowed, however</li>
+              <li>Deep Impact projects become viable funded start-ups</li>
+          </ul>
+          -->
+
         </div>
       </div>
     </section>

--- a/fall26.html
+++ b/fall26.html
@@ -179,9 +179,9 @@
           <div class="studio-panel-dark">
             <h3>Course Pillars</h3>
             <ul>
-              <li><strong>Innovation (20%):</strong> explore how AI may change over the next 2&ndash;3 years, including autonomous workflows, shared standards for the agentic web, multimodal reasoning, robotics, and services used by agents.</li>
-              <li><strong>Agent Infrastructure and Products (30%):</strong> design useful infrastructure, services, and products for AI agents and the agentic web.</li>
-              <li><strong>Technical Building (50%):</strong> use current AI tools and frameworks to build working agent systems, LLM-powered tools, APIs, and automated workflows.</li>
+              <li><strong>Innovation:</strong> explore how agentic AI may evolve over the next 2&ndash;3 years, including autonomous workflows, shared standards for the agentic web, multimodal reasoning, robotics, and services used by agents.</li>
+              <li><strong>Agent Infrastructure and Products:</strong> design useful infrastructure, services, and products for AI agents and the agentic web.</li>
+              <li><strong>Technical Building:</strong> use current AI tools and frameworks to build working agent systems, LLM-powered tools, APIs, and automated workflows.</li>
             </ul>
           </div>
         </div>
@@ -225,10 +225,21 @@
               <li><strong>First wave:</strong> apply by August 1, 2026.</li>
               <li><strong>Second wave:</strong> apply by August 15, 2026.</li>
               <li><strong>Final wave:</strong> apply by September 1, 2026.</li>
-              <li><strong>Late applications:</strong> a few seats may be available after September 1, but admission is not guaranteed.</li>
+              <li><strong>Late applications:</strong> a few seats may be available after September&nbsp;1, but admission is not guaranteed.</li>
             </ul>
           </div>
 
+          <div class="studio-panel">
+            <h3>Required Application Materials</h3>
+            <ul>
+              <li>Complete the <a href="https://forms.gle/qD21EGUYxMnqYsN39">Fall 2026 questionnaire</a>.</li>
+              <li>Submit the required short mini-project on AI agents. Details will be announced in mid-July 2026, and the project will be reviewed as part of your application.</li>
+              <li>Complete any additional registration forms required by MIT or Harvard.</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="studio-grid two-col">
           <div class="studio-panel">
             <h3>How Applications Are Reviewed</h3>
             <ul>
@@ -236,17 +247,6 @@
               <li>Strong early applicants may receive a decision before the semester starts. Other applicants may be placed on a waitlist until course capacity is confirmed.</li>
               <li>The course is selective, so completing every required step does not guarantee admission.</li>
               <li>MIT registration or Canvas access does not replace the course application; students who already have Canvas access should follow the Getting Started announcement and complete the same application steps.</li>
-            </ul>
-          </div>
-        </div>
-
-        <div class="studio-grid two-col">
-          <div class="studio-panel">
-            <h3>Required Application Materials</h3>
-            <ul>
-              <li>Complete the <a href="https://forms.gle/qD21EGUYxMnqYsN39">Fall 2026 questionnaire</a>.</li>
-              <li>Submit the required short mini-project on AI agents. Details will be announced in mid-July 2026, and the project will be reviewed as part of your application.</li>
-              <li>Complete any additional registration forms required by MIT or Harvard.</li>
             </ul>
           </div>
 

--- a/fall26.html
+++ b/fall26.html
@@ -15,7 +15,7 @@
 
     <meta name="title" content="AI Studio Fall 2026 @ MIT">
     <meta name="description"
-      content="AI Studio Fall 2026 @ MIT">
+      content="AI Studio Fall 2026 @ MIT: products and infrastructure for AI agents as users">
     <meta property="og:image" content="assets/img/ai-studio-logo-180.png">
 
     <!-- Google Fonts -->
@@ -85,9 +85,13 @@
           <li><a href="#">Fall 2026</a>
             <ul>
               <li><a href="#overview">Overview</a></li>
+              <li><a href="#admissions">Admissions</a></li>
+              <li><a href="#projects">Projects</a></li>
+              <li><a href="#grading">Grading</a></li>
               <li><a href="#speakers">Instructors</a></li>
               <li><a href="#background">Background</a></li>
               <li><a href="#course">Course Outline</a></li>
+              <li><a href="#faq">FAQ</a></li>
             </ul>
           </li>
           <li><a href="#">Past Semesters</a>
@@ -100,7 +104,7 @@
               <li><a href="fall23.html">Fall 2023</a></li>
             </ul>
           </li>
-          <li class="apply-btn"><a href="#overview">Apply Now</a></li>
+          <li class="apply-btn"><a href="https://forms.gle/qD21EGUYxMnqYsN39">Apply Now</a></li>
         </ul>
       </nav><!-- #nav-menu-container -->
     </div>
@@ -122,7 +126,7 @@
 
 
       <h1 class="mb-2 pb-0"><span style="color: #A31F34">AI Studio Course</span></h1>
-      <h2 class="mb-2 pb-0"><span style="color: #A31F34">AI Agents and Agentic Web</span></h2>
+      <h2 class="mb-2 pb-0"><span style="color: #A31F34">Products and Infrastructure for AI Agents</span></h2>
       <h3 class="mb-2 pb-0"><span style="color: #A31F34; font-weight: bold">MAS.665</span></h3>
       <p id="sub-heading" class="mb-4 pb-0">MAS.664 / MAS.665 / EC.731 / IDS.865</p>
       <p class="mb-0 pb-0">(prev: Foundations of AI Ventures, AI Venture Studio, AI for Impact)</p>
@@ -149,62 +153,228 @@
 
 
   <main id="main">
-    <section id="coordination" class="section-with-bg">
+    <section id="coordination" class="section-with-bg studio-overview">
       <div class="container" id="overview">
         <div class="section-header-inv">
           <h2 style="font-size:xx-large">Overview</h2>
         </div>
-        <div class="justify-content-center" data-aos-delay="700">
+        <div data-aos-delay="700">
 
-        <p style="color: white">
-
-          <b>Build the agentic future</b>
-          <br>
-            This MIT course teaches students to build autonomous AI agents that plan, coordinate, and execute complex workflows across distributed web systems. Students learn agent architectures, inter-agent protocols, web automation frameworks, and methods for decentralized coordination, while mastering AI-native coding and multimodal integration.
-            <br><br>
-            Through hands-on projects, students build sophisticated agentic applications: from automated workflow orchestration to intelligent web scraping and dynamic API coordination. The course combines solid technical foundations with innovative product development opportunities in this emerging infrastructure layer. Students learn to design AI agents with global impact, validate ideas through AI-assisted research and interviews, and move working prototypes toward market-ready solutions.
-            <br><br>
-            The course features insights from distributed AI researchers, web platform architects, and technical founders. It culminates with a technical demo day showcasing next-generation agentic web systems.
-          <br><br>
-
-          <b>Course pillars</b>
-          <br/>
-          1. Innovation (20%): Cultivating a deep understanding of where AI is going to be in 2-3 years or more. Multimodal reasoning, autonomous workflows, personalized agents, robotics, and more.
-          <br>
-          2. Human Centered design and Final Project (30%): Learn how to design innovative AI products that can make a truly global impact, validate ideas with AI-powered outreach and interviews, for compelling market-ready solutions.
-          <br>
-          3. Technical Building (50%): We will teach you about hands-on creation of agentic systems, LLM-based tools, and automated pipelines using the latest AI stacks and frameworks.
-          <br>
-
-
-        <br>
-        <b>Follow these steps to register for the course:</b>
-        </p>
-        <ul style="font-size:0.85rem; margin-top: -1.5rem;">
-          <li>Step 0: <a href="https://forms.gle/qD21EGUYxMnqYsN39" style="color:yellow;">Fill out the Fall 2026 questionnaire</a>.</li>
-          <li>Step 1: Course registration logistics for MIT and Harvard students are <em>TBA</em>.</li>
-          <li>Step 2: Recommended prep work + mini build sprint is <em>TBA</em> (expect short AI tooling primers).</li>
-          <li>Step 3: Application review dates are <em>TBA</em>. We will notify both accepted and rejected students by email. Submitting required forms does not guarantee acceptance due to limited space and high interest in the class.</li>
-          <li>Step 4: Late application and reconsideration process is <em>TBA</em>.</li>
-        </ul>
-
-        <p style="color: white">
-          Pre-Course Info Session &amp; Social: <em>TBA</em>
+        <p class="studio-kicker">
+          Build products and infrastructure for AI agents as the primary users: APIs, tools, services, protocols, environments, and trust layers that autonomous agents can discover, call, compose, and rely on.
         </p>
 
-        <center>
-          <p style="color: white"><b>
-          Class Schedule: Thursdays, 10 AM-12 PM, Room E14-633, MIT Media Lab (starting Sep 3 or Sep 10).
-          </b></p>
-          <p style="color: white; margin-bottom:0;">Final start date and calendar links will be posted once finalized.</p>
+        <div class="studio-grid two-col dark">
+          <div class="studio-panel-dark">
+            <h3>Build for AI Agents as Users</h3>
+            <p>
+              Students learn how to design systems that agents can use directly, with people acting as supervisors, beneficiaries, or operators rather than the primary users.
+            </p>
+            <ul>
+              <li>Create agent-consumable APIs, tools, services, and workflow surfaces.</li>
+              <li>Build infrastructure for identity, memory, permissions, payments, observability, evaluations, and trust.</li>
+              <li>Validate whether agents can discover, understand, call, and compose what you build.</li>
+            </ul>
+          </div>
 
-          <br><br>
-        </center>
+          <div class="studio-panel-dark">
+            <h3>Course Pillars</h3>
+            <ul>
+              <li><strong>Innovation (20%):</strong> understand where AI is going in 2-3 years, including autonomous workflows, agent protocols, multimodal reasoning, robotics, and agent economies.</li>
+              <li><strong>Agent Products and Infrastructure (30%):</strong> build products where AI agents are the primary users and people set goals, constraints, and accountability.</li>
+              <li><strong>Technical Building (50%):</strong> create agent-consumable systems, LLM-based tools, service endpoints, and automated pipelines using current AI stacks and frameworks.</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="studio-grid two-col dark">
+          <div class="studio-panel-dark">
+            <h3>Course Format</h3>
+            <ul>
+              <li>Weekly class meetings with technical lectures, discussion, and applied examples.</li>
+              <li>Regular assignments and quizzes to build fluency with agent tools, APIs, evaluation, and deployment.</li>
+              <li>Hands-on project work throughout the semester, with workshops when scheduled.</li>
+              <li>A team final project with checkpoints, mentor feedback, and a technical Demo Day in December 2026.</li>
+            </ul>
+          </div>
+
+          <div class="studio-panel-dark">
+            <h3>Final Project Deliverable</h3>
+            <ul>
+              <li>One working agent-facing product, service, protocol, or infrastructure component.</li>
+              <li>The final artifact should be usable by AI agents through a clear interface, API, tool contract, or runtime environment.</li>
+              <li>Teams must document how agents use it and show evidence that it works under realistic agent use.</li>
+              <li>The semester ends with a concise final presentation and live technical demo.</li>
+            </ul>
+          </div>
+        </div>
 
         </div>
       </div>
     </section>
 
+    <section id="admissions" class="studio-light-section">
+      <div class="container">
+        <div class="section-header">
+          <h2 style="color: #191919; font-size:xx-large">Admissions and Logistics</h2>
+        </div>
+
+        <div class="studio-grid two-col">
+          <div class="studio-panel">
+            <h3>Application Waves</h3>
+            <ul>
+              <li><strong>Priority wave:</strong> apply by August 1, 2026.</li>
+              <li><strong>Second wave:</strong> apply by August 15, 2026.</li>
+              <li><strong>Final regular wave:</strong> apply by September 1, 2026.</li>
+              <li><strong>Late seats:</strong> a small pool may be held for students who discover the course late, but late admission is not guaranteed.</li>
+            </ul>
+          </div>
+
+          <div class="studio-panel">
+            <h3>Selection Standard</h3>
+            <ul>
+              <li>Strong early applicants can be accepted before the semester starts.</li>
+              <li>Borderline applications may be rejected even if seats are available.</li>
+              <li>Submitting required materials does not guarantee admission.</li>
+              <li>Registration or Canvas access does not replace the application process.</li>
+              <li>Students already in Canvas should follow the Getting Started announcement and complete the same application steps.</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="studio-grid two-col">
+          <div class="studio-panel">
+            <h3>Required Application Materials</h3>
+            <ul>
+              <li><a href="https://forms.gle/qD21EGUYxMnqYsN39">Fall 2026 questionnaire</a>.</li>
+              <li>Required short agency and agentic AI mini-build for admission review.</li>
+              <li>Brief technical background and project interest review.</li>
+              <li>Any additional course registration forms required by MIT or Harvard.</li>
+            </ul>
+          </div>
+
+          <div class="studio-panel">
+            <h3>Communication Rules</h3>
+            <ul>
+              <li>Use Canvas for course logistics, assignments, deadlines, project questions, and general course questions.</li>
+              <li>Use email only for very personal questions that contain sensitive personal information.</li>
+              <li>Course event details will be posted on Canvas or sent by email.</li>
+              <li>Every course question should include your name, school, team if any, and the specific action you need.</li>
+              <li>If you use multiple names, choose one name and use it consistently for all course communication from application through final project.</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="studio-note">
+          The course may use an AI course assistant to answer common logistics questions, route support requests, and help students find Canvas materials. Course staff remain the escalation path for admissions, grading, and policy decisions.
+        </div>
+      </div>
+    </section>
+
+    <section id="projects" class="studio-dark-section">
+      <div class="container">
+        <div class="section-header-inv">
+          <h2 style="font-size:xx-large">Projects and Demo Day</h2>
+        </div>
+
+        <p class="studio-kicker">
+          Fall 2026 projects will center on agent-facing products and infrastructure: things AI agents can use as clients, collaborators, buyers, delegates, or operators in an agentic web environment.
+        </p>
+
+        <div class="studio-grid two-col dark">
+          <div class="studio-panel-dark">
+            <h3>Build Theme</h3>
+            <ul>
+              <li>Students may build agent-facing products, API-backed services, tool surfaces, infrastructure modules, agent environments, or security and reliability systems.</li>
+              <li>Projects should make clear what an AI agent can do with the product or infrastructure, and what contract the system exposes to agents.</li>
+              <li>Projects should be designed for environments where multiple agents, services, and infrastructure components interact.</li>
+              <li>Examples include identity, reputation, permissions, payments-style flows, memory, observability, evaluations, red-team agents, service marketplaces, and workflow automation.</li>
+            </ul>
+          </div>
+
+          <div class="studio-panel-dark">
+            <h3>Demo Day Rules</h3>
+            <ul>
+              <li>Demo Day is planned for December 2026; exact date TBA.</li>
+              <li>Final demo title, team roster, URL, deck, and table or booth needs are due two weeks before Demo Day.</li>
+              <li>After the freeze date, no new projects, last-minute demo swaps, table changes, or major logistics changes are accepted.</li>
+              <li>Expected demo length is 2-3 minutes per project, with timing enforced.</li>
+              <li>Teams that miss the freeze date or do not present may receive no or reduced project/demo credit.</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="studio-grid two-col dark">
+          <div class="studio-panel-dark">
+            <h3>Mentor Feedback</h3>
+            <ul>
+              <li>Each project is expected to meet with at least one technical mentor.</li>
+              <li>The target is three mentor touchpoints during the semester.</li>
+              <li>Mentors will be matched to a small number of projects so feedback can be specific.</li>
+              <li>Teams should come to mentor sessions with specific technical questions, a working artifact, and clear next steps.</li>
+            </ul>
+          </div>
+
+          <div class="studio-panel-dark">
+            <h3>Technical Support</h3>
+            <ul>
+              <li>Technical workshops and support sessions may be offered during the semester.</li>
+              <li>Topics and timing will be announced after the final course schedule is set.</li>
+              <li>Peer groups may be formed for homework review and project feedback.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="grading" class="studio-light-section">
+      <div class="container">
+        <div class="section-header">
+          <h2 style="color: #191919; font-size:xx-large">Grading</h2>
+        </div>
+
+        <p class="studio-copy-dark">
+          Final grading follows the course pillars: Innovation (20%), Agent Products and Infrastructure (30%), and Technical Building (50%). Attendance, quizzes, peer feedback, mentor engagement, and Demo Day readiness are evaluated through those pillars.
+        </p>
+
+        <div class="table-responsive">
+          <table class="studio-table">
+            <thead>
+              <tr>
+                <th>Grade</th>
+                <th>What it means</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>A+</td>
+                <td>Exceptional technical build, original insight, clear validation that agents can use the product or infrastructure reliably, polished live demo ready before the freeze date, clear documentation, active peer feedback, and three strong mentor touchpoints.</td>
+              </tr>
+              <tr>
+                <td>A</td>
+                <td>All required work completed on time, strong working MVP or infrastructure component, clear agent-user contract, good technical execution, active participation, and on-time Demo Day presentation.</td>
+              </tr>
+              <tr>
+                <td>A-</td>
+                <td>Complete and serious work with minor gaps in technical depth, validation, polish, documentation, or consistency. Demo works, but the project is less robust or less ambitious than A-level work.</td>
+              </tr>
+              <tr>
+                <td>B+ / B</td>
+                <td>Substantial participation and a partial working project, but one major area is weak: missed milestone, thin technical implementation, limited validation, weak collaboration, or incomplete final demo readiness.</td>
+              </tr>
+              <tr>
+                <td>B- / C</td>
+                <td>Inconsistent participation, late or missing assignments, limited project progress, poor communication, or a demo that does not show a credible working system.</td>
+              </tr>
+              <tr>
+                <td>No credit / Fail</td>
+                <td>Failure to submit required work, failure to present when required, academic integrity problems, or repeated lack of engagement with course logistics and staff.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
 
     <div id="vaccines-for-all">
       <!-- ======= agenda Section =======  -->
@@ -316,8 +486,8 @@
           <div class="section-header">
             <h2 style="color: #191919">Mentors and Guest Speakers</h2>
           </div>
-          <p style="color: #191919; text-align: center; font-size: 1.1rem;">
-            To be announced
+          <p style="color: #191919; text-align: center; font-size: 1.1rem; max-width: 900px; margin: 0 auto 30px;">
+            Fall 2026 mentors and speakers will be announced on a rolling basis. The course is prioritizing technical industry speakers, founders, engineers, researchers, and venture partners who can give concrete feedback on agent architecture, product strategy, deployment, reliability, and go-to-market execution.
           </p>
 
         </div>
@@ -333,13 +503,12 @@
           <h2 style="color: #191919; font-size:xx-large">Background</h2>
         </div>
 
-        <div class= data-aos-delay="700">
+        <div data-aos-delay="700">
           <p style="color: #191919">
-          Almost 25% of students from this course transform their projects into innovative products. The program, which evolved from Sandy Pentland's "Development Ventures," has established a strong track record of launching successful student projects through its Demo Day showcase.
-          <br>
-          <br>
-          Our previous class links can be found here:
-          <br>
+            The course evolved from Sandy Pentland's Development Ventures and has a long track record of helping students turn class projects into working products and ventures.
+          </p>
+
+          <p style="color: #191919; margin-bottom: 12px;">Previous offerings:</p>
           <ul style="font-size:0.85rem; padding-right: 8rem;">
             <li><a href="https://aiforimpact.github.io/spring26.html">Spring'26: AI Studio</a></li>
             <li><a href="https://aiforimpact.github.io/fall25.html">Fall'25: AI Studio</a></li>
@@ -355,123 +524,70 @@
             <li><a href="https://web.archive.org/web/https://stellar.mit.edu/S/course/MAS/fa20/MAS.665/">Fall'20: Global Ventures ~ Data and AI for Resilience after COVID19</a></li>
             <li><a href="https://web.archive.org/web/https://stellar.mit.edu/S/course/MAS/sp20/MAS.664/">Spring'20: AI for Impact ~ Towards Solving Societal-Scale Problems via Media Ventures</a></li>
           </ul>
-          </p>
-
-          <p style="color: #191919">
-          All other previous AI for Impact/Global Ventures class links can be found here:
-
-          <br>
-
-          <ul style="font-size:0.85rem; padding-right: 8rem;">
-            <li><a href="https://web.archive.org/web/https://stellar.mit.edu/courseguide/course/MAS/sp22/MAS.664/index.html">Fall Term</a></li>
-            <li><a href="https://web.archive.org/web/https://stellar.mit.edu/courseguide/course/MAS/fa21/MAS.665/index.html">Spring Term</a></li>
-          </ul>
-          </p>
-
-          <!-- A recent MIT News article talked about the history of our course "AI for Impact" (MAS.664) and its evolution over time. The entrepreneurship-focused class has a history of about a quarter of students continuing on to start real ventures. The course started by Sandy Pentland, earlier called Development Ventures was focused on leveraging entrepreneurship to drive societal scale impact. The highly anticipated Demo Day showcase has also been reported on. -->
-          <!-- Almost 25% of course's students launch startups from their projects. The course has a history of innovation, and a long history of innovation as outlined in these news articles.  -->
-          <!-- Almost 25% of students from this course transform their projects into startups. The program, which evolved from Sandy Pentland's "Development Ventures," has established a strong track record of launching successful student ventures through its Demo Day showcase. -->
-          <!-- <br>
-          <br>
-
-          <ul style="font-size:0.85rem; padding-right: 8rem;">
-              <li><a href="https://www.media.mit.edu/posts/ai-and-web3-for-impact-venture-studio-demo-day-2023/">Recent Demo Day Report</a></li>
-              <li><a href="https://news.mit.edu/2021/ai-impact-lives-its-name-0816">MIT News: "AI for Impact" lives up to its name</a></li>
-          </ul> -->
-          <br>
-          <br>
-
-
-          </p>
         </div>
       </div>
     </section>
 
-    <section id="coordination" class="section-with-bg">
+    <section id="coordination" class="section-with-bg studio-course-outline">
       <div class="container" id="course">
         <div class="section-header-inv">
           <h2 style="font-size:xx-large">Course Outline</h2>
         </div>
 
-        <p style="color:white; font-size: 1rem; text-align:center;">
-          Updated Fall 2026 calendar and weekly outline are TBA; expect a similar studio cadence with refreshed themes.
+        <p class="studio-kicker">
+          The detailed weekly calendar is TBA and will be posted once the MIT room and semester calendar are finalized.
         </p>
 
-        <br>
+        <div class="studio-grid two-col dark">
+          <div class="studio-panel-dark">
+            <h3>Key Dates</h3>
+            <ul>
+              <li>First class: Thu, Sep 3 or Thu, Sep 10, 2026.</li>
+              <li>Demo package freeze: two weeks before Demo Day.</li>
+              <li>Final presentations / Demo Day: December 2026.</li>
+            </ul>
+          </div>
 
-        <div class="justify-content-left" data-aos-delay="700">
-          <p style="color: white; font-size:large; margin-bottom: 10px;"><u>Class Goals</u>:</p>
-          <ul style="font-size:0.85rem">
-              <li>Guide students to identify, evaluate, and build high-impact projects with AI. Focus on deep technology applications that are best suited to students with top engineering and design skills at MIT.</li>
-              <li>Advance "Big Ideas" into MVP-seed-stage for commercial consideration.</li>
-              <li>Teach the technical fundamentals of the modern AI stack (rapid prototyping, deployment, and model management). </li>
-              <li>Discuss practical trade-offs in AI product development (model accuracy, efficiency, and latency). </li>
-
-
-          </ul>
-
-
-          <p style="color: white; font-size:large; margin-bottom: 10px;"><u>Timeline</u>:</p>
-          <ul style="font-size:0.85rem">
-            <li>Meet and greet + team formation mixer: <em>TBA</em></li>
-            <li>First day of class: <em>Thu, Sep 3 or Thu, Sep 10, 2026</em></li>
-            <li>Final class presentations / Demo Day: <em>December 2026</em></li>
-          </ul>
-
-
-          <p style="color: white; font-size:large; margin-bottom: 10px;"><u>Class Structure</u>:</p>
-          <ul style="font-size:0.85rem">
-            <li>Studio format, with team projects with 2-3 students per team</li>
-            <li>Guest speakers share leading-edge thinking</li>
-            <li>NB: You can use this course for Entrepreneurship Minor credits. Contact <a href="mailto:eiminor_admin@mit.edu" style="color:yellow;">eiminor_admin@mit.edu</a> for the application form and meet E&I minor advisor, Reza Rahaman (rezar@mit.edu) for sign off.</li>
-            <li>Minimum Viable Product (MVP) by the end of the term</li>
-            <li>Demo Day</li>
-          </ul>
+          <div class="studio-panel-dark">
+            <h3>Calendar Notes</h3>
+            <ul>
+              <li>The public weekly schedule will be linked here when finalized.</li>
+              <li>Assignment deadlines and project milestones will be published on Canvas.</li>
+              <li>Workshop, mentor, and guest speaker dates are TBA.</li>
+              <li>Entrepreneurship Minor credit may be available; contact <a href="mailto:eiminor_admin@mit.edu" style="color:yellow;">eiminor_admin@mit.edu</a> for details.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
 
 
-          <p style="color: white; font-size:large; margin-bottom: 10px;"><u>Support for Students</u>:</p>
+    <section id="faq" class="studio-light-section">
+      <div class="container">
+        <div class="section-header">
+          <h2 style="color: #191919; font-size:xx-large">FAQ</h2>
+        </div>
 
-          <ul style="font-size:0.85rem">
-              <li>Weekly class mentor meetings and guest lecture blocks (exact timing TBA)</li>
-              <li>Class visits to local start-ups and technology companies</li>
-              <li>Data and AI scientists from startups for experience</li>
-              <li>Sessions with startup coaches</li>
-          </ul>
+        <div class="studio-grid two-col">
+          <div class="studio-panel">
+            <h3>Can non-technical students take the course?</h3>
+            <p>Yes, if they are ready to build. Teams should balance product, design, research, and engineering strengths.</p>
+          </div>
 
-          <br/>
-          <br />
-          <!-- <p style="color: white; font-size:x-large; margin-bottom: 10px;"><u>Funding</u>:</p>
-          <ul style="font-size:0.85rem">
-              <li>Teams will receive milestone-based seed funds</li>
-          </ul> -->
+          <div class="studio-panel">
+            <h3>Are course homeworks part of admission?</h3>
+            <p>No. The required admission mini-build is part of application review. Regular course homework starts after admission and happens during the course.</p>
+          </div>
 
+          <div class="studio-panel">
+            <h3>Is collaboration allowed?</h3>
+            <p>Yes. Peer groups and mentor feedback are part of the course. Students should help each other learn while submitting their own work and documenting team contributions clearly.</p>
+          </div>
 
-          <!-- <p style="color: white; font-size:x-large"><u>Course Support</u>:</p>
-          <div class="row justify-content-left speaker-row" style="margin: auto;">
-            <div class="col-lg-3 col-md-6 col-sm-6" style="width: 85%; padding: 1em;">
-              <a href="https://nikhilbehari.github.io" target="_blank">
-                <div class="speaker">
-                  <img src="assets/img/speakers/Nikhil_Behari.png" alt="Nikhil Behari" style="width: 100%; height: 100%; object-fit: cover; aspect-ratio: 1 / 1;">
-                  <div class="details" style="text-align: center; color: white; margin-top: 0.5em;">
-                    <h4 style="color: white; margin-bottom: 0.2em;">Nikhil Behari</h3>
-                    <p style="color: white; margin: 0;">Graduate Student, MIT Media Lab</p>
-                  </div>
-                </div>
-              </a>
-            </div> -->
-
-          <!--
-          <p style="color: white; font-size:x-large"><u>Expected Short and Long Term Outcomes</u>:</p>
-          <ul style="font-size:0.85rem; padding-right:5rem;">
-              <li>Student teams develop MVP and project "pitch" for final review</li>
-              <li>Student teams can submit projects for consideration in venture incubator/accelerators, 100K, Deshpande Grants etc.</li>
-              <li>Projects can be considered for funding by the MIT Engine, E14 Fund, and other investment funds</li>
-              <li>Visualize Venture Studio creates an annual event to invite key stakeholders including the general innovation community to showcase big project ideas</li>
-              <li>Visualize Venture Studio creates a funded consortium (GIFTS) with on-going course sponsorship from a diverse group of financial institutions (e.g., Venture capital firms of all stages, Investment Banks, LPs, family offices, and HNW individuals), corporates, and NGOs. No branding is allowed, however</li>
-              <li>Deep Impact projects become viable funded start-ups</li>
-          </ul>
-          -->
-
+          <div class="studio-panel">
+            <h3>Who should mentor?</h3>
+            <p>Technical founders, engineers, researchers, and industry partners who can help students build and evaluate real agentic systems should contact the course team.</p>
+          </div>
         </div>
       </div>
     </section>

--- a/fall26.html
+++ b/fall26.html
@@ -89,7 +89,7 @@
               <li hidden><a href="#grading">Grading</a></li>
               <li><a href="#speakers">Instructors</a></li>
               <li><a href="#background">Background</a></li>
-              <li><a href="#course">Course Outline</a></li>
+              <li><a href="#course">Course Schedule</a></li>
               <li><a href="#faq">FAQ</a></li>
             </ul>
           </li>
@@ -125,10 +125,11 @@
 
 
       <h1 class="mb-2 pb-0"><span style="color: #A31F34">AI Studio Course</span></h1>
-      <h2 class="mb-2 pb-0"><span style="color: #A31F34">Infrastructure and Products for AI Agents</span></h2>
-      <h3 class="mb-2 pb-0"><span style="color: #A31F34; font-weight: bold">MAS.665</span></h3>
-      <p id="sub-heading" class="mb-4 pb-0">MAS.664 / MAS.665 / EC.731 / IDS.865</p>
-      <p class="mb-0 pb-0">(prev: Foundations of AI Ventures, AI Venture Studio, AI for Impact)</p>
+      <h2 class="mb-2 pb-0"><span style="color: #A31F34">AI Agents and Agentic Web</span></h2>
+      <p class="mb-3 pb-0">A hands-on MIT course on infrastructure, tools, services, and products for AI agents.</p>
+      <h3 class="mt-4 mb-2 pb-0"><span style="color: #A31F34; font-weight: bold">MAS.665</span></h3>
+      <p id="sub-heading" class="mb-1 pb-0" style="color: #777;">MAS.664 / MAS.665 / EC.731 / IDS.865</p>
+      <p class="mb-0 pb-0" style="color: #777;">(prev: Foundations of AI Ventures, AI Venture Studio, AI for Impact)</p>
 
       <!-- <h3 class="mb-2 pb-0"><span class="mb-4 pb-0" >MAS.664 / MAS.665 / 15.375 / EC.731 / IDS.865</span></h3> -->
       <!-- <h3 class="mb-2 pb-0"><span class="mb-4 pb-0" >MAS.664 / MAS.665 / 15.375 / EC.731 / IDS.865</span></h3> -->
@@ -160,18 +161,19 @@
         <div data-aos-delay="700">
 
         <p class="studio-kicker">
-          Build the infrastructure and products that make the agentic web possible, including APIs, tools, services, shared standards, environments, and trust systems that AI agents can find, use, combine, and rely on.
+          Build infrastructure, tools, services, and products for the Agentic Web that AI agents can discover, use, and combine.
         </p>
 
         <div class="studio-grid two-col dark">
           <div class="studio-panel-dark">
-            <h3>Build Infrastructure and Products for AI Agents</h3>
+            <h3>Course Focus</h3>
             <p>
-              In this course, you will design software that AI agents can use directly to complete tasks and interact with other systems. Together, these connected agents, tools, and services form the agentic web.
+              In this course, you will design infrastructure that enables AI agents to complete tasks and interact with other systems.
             </p>
             <ul>
-              <li>Create APIs, tools, and services that agents can discover and use.</li>
+              <li>Build infrastructure, tools, and services that agents can discover and use.</li>
               <li>Build essential capabilities such as identity, memory, permissions, payments, monitoring, testing, and security.</li>
+              <li>Learn and apply agent architectures, inter-agent protocols, web automation, decentralized coordination, model management, and trade-offs in accuracy, efficiency, and latency.</li>
               <li>Test whether agents can understand your system, use it correctly, and combine it with other tools.</li>
             </ul>
           </div>
@@ -179,9 +181,9 @@
           <div class="studio-panel-dark">
             <h3>Course Pillars</h3>
             <ul>
-              <li><strong>Innovation:</strong> explore how agentic AI may evolve over the next 2&ndash;3 years, including autonomous workflows, shared standards for the agentic web, multimodal reasoning, robotics, and services used by agents.</li>
-              <li><strong>Agent Infrastructure and Products:</strong> design useful infrastructure, services, and products for AI agents and the agentic web.</li>
-              <li><strong>Technical Building:</strong> use current AI tools and frameworks to build working agent systems, LLM-powered tools, APIs, and automated workflows.</li>
+              <li><strong>Innovation:</strong> explore how agentic AI may evolve over the next 2&ndash;3 years, including autonomous workflows, shared standards for agents, multimodal reasoning, and robotics.</li>
+              <li><strong>Agent Infrastructure and Products:</strong> design useful infrastructure, services, and products for AI agents.</li>
+              <li><strong>Technical Building:</strong> use current AI tools and frameworks to build working agent systems, LLM-powered tools, service endpoints, and automated workflows.</li>
             </ul>
           </div>
         </div>
@@ -190,20 +192,19 @@
           <div class="studio-panel-dark">
             <h3>Course Format</h3>
             <ul>
-              <li>Weekly class meetings on Thursdays, 10:00 AM&ndash;12:00 PM, with lectures, discussion, and applied examples.</li>
-              <li>Regular assignments and quizzes on agent tools, APIs, testing, and deployment.</li>
-              <li>Hands-on project work in small teams of 1&ndash;3 students throughout the semester, with workshops when scheduled.</li>
-              <li>A team final project with checkpoints, mentor feedback, and a Demo Day in December 2026.</li>
+              <li>Weekly classes include lectures and discussion.</li>
+              <li>Regular assignments and quizzes on agent tools, interfaces, testing, and deployment.</li>
+              <li>Hands-on project work in small teams of 1&ndash;3 students throughout the semester.</li>
+              <li>A team final project with checkpoints, mentor feedback, and a Demo&nbsp;Day.</li>
             </ul>
           </div>
 
           <div class="studio-panel-dark">
-            <h3>What You Will Deliver</h3>
+            <h3>Final Project</h3>
             <ul>
-              <li>A working product, service, shared standard, or infrastructure component that contributes to the agentic web.</li>
-              <li>A clear way for agents to interact with it, such as an API, tool interface, or environment where the agent runs.</li>
+              <li>A working minimum viable product (MVP), such as an infrastructure component, product, service, or shared standard.</li>
+              <li>A clear way for agents to interact with it, such as a tool interface or environment where the agent runs.</li>
               <li>Documentation showing how an agent uses it, plus evidence that it works in realistic scenarios.</li>
-              <li>The semester ends with a concise final presentation and live technical demo.</li>
             </ul>
           </div>
         </div>
@@ -243,10 +244,9 @@
           <div class="studio-panel">
             <h3>How Applications Are Reviewed</h3>
             <ul>
-              <li>We look for readiness to build, relevant experience, clear interest in the course, and the ability to contribute to a project team.</li>
-              <li>Strong early applicants may receive a decision before the semester starts. Other applicants may be placed on a waitlist until course capacity is confirmed.</li>
-              <li>The course is selective, so completing every required step does not guarantee admission.</li>
-              <li>MIT registration or Canvas access does not replace the course application; students who already have Canvas access should follow the Getting Started announcement and complete the same application steps.</li>
+              <li>We assess readiness to build, relevant experience, interest in the course, and expected contribution to a team.</li>
+              <li>In each wave, applicants may be accepted, rejected, or waitlisted. Earlier waves receive preference, so apply early if possible.</li>
+              <li>Admission is selective. MIT registration or Canvas access does not replace the course application.</li>
             </ul>
           </div>
 
@@ -254,7 +254,7 @@
             <h3>How to Contact the Course Team</h3>
             <ul>
               <li>Once admitted, use Canvas for assignments, deadlines, project questions, logistics, and other general questions.</li>
-              <li>Use email only for private matters that include sensitive personal information. When asking for help by email, include your full name, school, team (if applicable), and the specific question or action you need.</li>
+              <li>Use email only for private matters that include sensitive personal information. Include your full name, school, team (if applicable), and requested action.</li>
               <li>Use the same full name and email address throughout your application, Canvas profile, course communications, and project work so we can identify you easily.</li>
             </ul>
           </div>
@@ -266,6 +266,40 @@
       </div>
     </section>
 
+    <section id="coordination" class="section-with-bg studio-course-outline">
+      <div class="container" id="course">
+        <div class="section-header-inv">
+          <h2 style="font-size:xx-large">Course Schedule</h2>
+        </div>
+
+        <p class="studio-kicker">
+          The detailed weekly calendar is TBA and will be posted once the semester calendar is finalized.
+        </p>
+
+        <div class="studio-grid two-col dark">
+          <div class="studio-panel-dark">
+            <h3>Class Meetings and Key Dates</h3>
+            <ul>
+              <li><strong>Weekly class:</strong> Thursdays, 10:00 AM&ndash;12:00 PM, in E14-633 at the MIT Media Lab.</li>
+              <li><strong>Pre-course information session and social:</strong> late August or early September 2026; details will be announced in advance.</li>
+              <li><strong>First class:</strong> Thursday, September 10, 2026.</li>
+              <li><strong>Final demo materials due:</strong> Thursday, November 19, 2026.</li>
+              <li><strong>Final presentations and Demo Day:</strong> Thursday, December 3, 2026.</li>
+            </ul>
+          </div>
+
+          <div class="studio-panel-dark">
+            <h3>Additional Information</h3>
+            <ul>
+              <li>Assignment deadlines and project milestones will be published on Canvas.</li>
+              <li>Workshop, mentor, and guest speaker dates will be announced in advance throughout the semester.</li>
+              <li>The course may count toward the Entrepreneurship and Innovation Minor. Contact <a href="mailto:eiminor_admin@mit.edu" style="color:yellow;">eiminor_admin@mit.edu</a> to confirm eligibility and requirements.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <section id="projects" class="studio-dark-section">
       <div class="container">
         <div class="section-header-inv">
@@ -273,28 +307,26 @@
         </div>
 
         <p class="studio-kicker">
-          Fall 2026 projects will contribute to the emerging agentic web: software that AI agents can use to complete tasks and interact with other agents and services.
+          Fall 2026 projects will contribute to the emerging Agentic Web: software that AI agents can use to complete tasks and interact with other agents and services.
         </p>
 
         <div class="studio-grid two-col dark">
           <div class="studio-panel-dark">
-            <h3>Project Scope</h3>
+            <h3>Project Requirements</h3>
             <ul>
-              <li>Examples include an agent-ready product, an API-based service, an infrastructure component, an environment for agents, or a security and reliability tool, among other possibilities.</li>
+              <li>Project types include but are not limited to infrastructure components, agent-ready products, services, environments for agents, and security or reliability tools.</li>
               <li>Your project should solve a clear problem and explain exactly what an AI agent can do with it.</li>
-              <li>Design your system for the agentic web so it can work with other agents, services, and infrastructure.</li>
-              <li>Example areas include identity, reputation, permissions, payments, memory, monitoring, evaluation, adversarial testing, service marketplaces, and workflow automation.</li>
+              <li>Design your system to integrate with infrastructure, agents, and services.</li>
+              <li>Possible focus areas include identity, reputation, permissions, payments, memory, monitoring, evaluation, adversarial testing, service marketplaces, and workflow automation.</li>
             </ul>
           </div>
 
           <div class="studio-panel-dark">
             <h3>Demo Day Requirements</h3>
             <ul>
-              <li>Demo Day is planned for December 2026; the exact date will be announced later.</li>
+              <li>Demo Day will be held on December 3, 2026.</li>
               <li>Two weeks before Demo Day, each team must submit its final title, team list, project URL, presentation deck, and any table or booth needs.</li>
-              <li>After that deadline, teams may not change projects, swap demos, or request major logistics changes.</li>
               <li>Each project will have 2&ndash;3 minutes for its live demo.</li>
-              <li>Missing the submission deadline or the presentation may reduce or eliminate the project and Demo Day portion of the grade.</li>
             </ul>
           </div>
         </div>
@@ -303,8 +335,7 @@
           <div class="studio-panel-dark">
             <h3>Mentor Feedback</h3>
             <ul>
-              <li>Each team is expected to work with at least one mentor.</li>
-              <li>Teams should plan for three mentor meetings during the semester.</li>
+              <li>Each team works with at least one mentor and should plan for three meetings.</li>
               <li>Mentors will be matched to a small number of projects so feedback can be specific.</li>
               <li>Teams should come to mentor sessions with specific technical questions, a working artifact, and clear next steps.</li>
             </ul>
@@ -314,7 +345,7 @@
             <h3>Technical Support</h3>
             <ul>
               <li>Technical workshops and support sessions will be offered during the semester.</li>
-              <li>Topics and timing may be announced in advance throughout the semester.</li>
+              <li>Topics and timing will be announced in advance throughout the semester.</li>
             </ul>
           </div>
         </div>
@@ -346,7 +377,7 @@
               </tr>
               <tr>
                 <td>A</td>
-                <td>All required work completed on time, a strong working prototype or infrastructure component, a clearly documented interface for agents, solid technical execution, active participation, and an on-time Demo Day presentation.</td>
+                <td>All required work completed on time, a strong working infrastructure component or prototype, a clearly documented interface for agents, solid technical execution, active participation, and an on-time Demo Day presentation.</td>
               </tr>
               <tr>
                 <td>A-</td>
@@ -522,41 +553,6 @@
       </div>
     </section>
 
-    <section id="coordination" class="section-with-bg studio-course-outline">
-      <div class="container" id="course">
-        <div class="section-header-inv">
-          <h2 style="font-size:xx-large">Course Outline</h2>
-        </div>
-
-        <p class="studio-kicker">
-          The detailed weekly calendar is TBA and will be posted once the semester calendar is finalized.
-        </p>
-
-        <div class="studio-grid two-col dark">
-          <div class="studio-panel-dark">
-            <h3>Key Dates</h3>
-            <ul>
-              <li><strong>Weekly class:</strong> Thursdays, 10:00 AM&ndash;12:00 PM, in E14-633 at the MIT Media Lab.</li>
-              <li><strong>First class:</strong> September 3 or September 10, 2026; the final date will be announced soon.</li>
-              <li><strong>Final demo materials due:</strong> two weeks before Demo Day.</li>
-              <li><strong>Final presentations and Demo Day:</strong> December 2026.</li>
-            </ul>
-          </div>
-
-          <div class="studio-panel-dark">
-            <h3>Calendar Notes</h3>
-            <ul>
-              <li>The full weekly schedule will be linked here when it is ready.</li>
-              <li>Assignment deadlines and project milestones will be published on Canvas.</li>
-              <li>Workshop, mentor, and guest speaker dates will be announced later.</li>
-              <li>The course may count toward the Entrepreneurship and Innovation Minor. Contact <a href="mailto:eiminor_admin@mit.edu" style="color:yellow;">eiminor_admin@mit.edu</a> to confirm eligibility and requirements.</li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </section>
-
-
     <section id="faq" class="studio-light-section">
       <div class="container">
         <div class="section-header">
@@ -566,7 +562,7 @@
         <div class="studio-grid two-col">
           <div class="studio-panel">
             <h3>Can non-technical students take the course?</h3>
-            <p>Yes. You do not need to be an expert programmer, but you must be ready to contribute to a working technical project. All team members are expected to build with coding agents. Strong teams combine product, design, research, and engineering skills.</p>
+            <p>Yes. You do not need to be an expert programmer, but you must be ready to contribute to a working technical project. All team members are expected to build with coding agents. Strong teams combine product, business, research, and engineering skills.</p>
           </div>
 
           <div class="studio-panel">
@@ -581,7 +577,7 @@
 
           <div class="studio-panel">
             <h3>Who should mentor?</h3>
-            <p>We welcome technical founders, engineers, researchers, and industry partners who can help students build and evaluate real AI agent systems. Interested mentors should contact the course team.</p>
+            <p>We welcome technical founders, engineers, researchers, and industry partners who can help students build and evaluate AI agent systems. Interested mentors should contact the course team.</p>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -5,8 +5,7 @@
   <meta charset="utf-8">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-  <title>AI Studio, MIT class</title>
-    <meta content="" name="descriptison">
+  <title>AI Studio at MIT</title>
     <meta content="" name="keywords">
 
     <!-- Favicons -->
@@ -15,7 +14,7 @@
 
     <meta name="title" content="AI Studio @ MIT">
     <meta name="description"
-      content="AI Studio @ MIT">
+      content="Explore AI Studio at MIT, a hands-on course where students build infrastructure and products for AI agents and the agentic web.">
     <meta property="og:image" content="assets/img/ai-studio-logo-180.png">
 
     <!-- Google Fonts -->
@@ -114,7 +113,7 @@
       <!-- <h1 class="mb-2 pb-0"><span style="color: #A31F34">AI Venture Studio </span></h1>
       <p id="sub-heading" class="mb-4 pb-0">MAS.664 / MAS.665 / 15.375 / EC.731 / IDS.865</p> -->
       <h1 class="mb-2 pb-0"><span style="color: #A31F34">AI Studio Course</span></h1>
-      <h2 class="mb-2 pb-0"><span style="color: #A31F34">AI Agents and Agentic Web</span></h2>
+      <h2 class="mb-2 pb-0"><span style="color: #A31F34">Infrastructure for AI Agents and the Agentic Web</span></h2>
       <p id="sub-heading" class="mb-4 pb-0">MAS.664 / MAS.665 / EC.731 / IDS.865</p>
       <div>
         <a href="./fall26.html" class="about-btn-2">Fall 2026</a>

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
               <li><a href="fall23.html">Fall 2023</a></li>
             </ul>
           </li>
-          <li class="apply-btn"><a href="spring26.html">Spring 2026</a></li>
+          <li class="apply-btn"><a href="fall26.html">Fall 2026</a></li>
 	</ul>
       </nav><!-- #nav-menu-container -->
     </div>
@@ -177,7 +177,7 @@
 
           <br>
           <br>
-          <a href="./spring26.html" style="color: white; text-decoration: underline;">Join the Spring 2026 class here.</a>
+          <a href="./fall26.html" style="color: white; text-decoration: underline;">Join the Fall 2026 class here.</a>
 
 
         </p>


### PR DESCRIPTION
## Summary
- Reframe the Fall 2026 page around building products, services, protocols, and infrastructure for AI agents as users.
- Clarify admissions, including application waves, the required admission mini-build, and Canvas/email communication rules.
- Simplify and deduplicate the overview, course outline, project expectations, grading, FAQ, and background copy.
- Update the homepage CTA to point to the Fall 2026 course page.
- Add responsive block-based styling for the updated Fall 2026 layout.

## Validation
- `git diff --check HEAD~1..HEAD`
- `python3 -m html.parser fall26.html`
- `python3 -m html.parser index.html`
- Verified local hash anchors for `fall26.html` and `index.html`.
